### PR TITLE
削除ダイアログ表示中に回転させるとonPositiveListenerが働かない不具合の修正

### DIFF
--- a/app/src/main/java/com/example/todoappsandbox/ui/list/DeleteConfirmDialog.kt
+++ b/app/src/main/java/com/example/todoappsandbox/ui/list/DeleteConfirmDialog.kt
@@ -5,24 +5,35 @@ import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
+import com.example.todoappsandbox.repository.db.TodoEntity
 
 class DeleteConfirmDialog : DialogFragment() {
 
     var onPositiveListener: DialogInterface.OnClickListener? = null
+    var onNegativeListener: DialogInterface.OnClickListener? = null
+    var entity: TodoEntity? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        if (savedInstanceState != null) dismiss()
         val activity = this.activity
         activity ?: return super.onCreateDialog(savedInstanceState)
 
         val builder = AlertDialog.Builder(activity)
             .setTitle("Delete")
-            .setMessage("This todo was deleted")
+            .setMessage(
+                "Are you sure to delete this todo?\n\nTitle: ${entity?.title
+                    ?: "Nothing"}\nDescription: ${entity?.description ?: "Nothing"}"
+            )
             .setPositiveButton("OK", onPositiveListener)
-            .setNegativeButton("CANCEL", null)
+            .setNegativeButton("CANCEL", onNegativeListener)
+        this.isCancelable = false
         return builder.create()
     }
 
     companion object {
         fun newInstance() = DeleteConfirmDialog()
+        fun newInstance(entity: TodoEntity) = DeleteConfirmDialog().apply {
+            this.entity = entity
+        }
     }
 }

--- a/app/src/main/java/com/example/todoappsandbox/ui/list/TodoListAdapter.kt
+++ b/app/src/main/java/com/example/todoappsandbox/ui/list/TodoListAdapter.kt
@@ -19,7 +19,6 @@ class TodoListAdapter(todoTouchEvent: TodoTouchEvent, val viewModel: TodoViewMod
     private var filteredTodos: List<TodoEntity> = arrayListOf()
 
     private val events = todoTouchEvent
-    private var isChecked = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = TodoItemBinding.inflate(
@@ -46,10 +45,6 @@ class TodoListAdapter(todoTouchEvent: TodoTouchEvent, val viewModel: TodoViewMod
         todos = todoItems
         filteredTodos = todoItems
         notifyDataSetChanged()
-    }
-
-    fun setIsChecked(isChecked: Boolean) {
-        this.isChecked = isChecked
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/example/todoappsandbox/ui/list/TodoViewModel.kt
+++ b/app/src/main/java/com/example/todoappsandbox/ui/list/TodoViewModel.kt
@@ -11,7 +11,7 @@ import com.example.todoappsandbox.utils.Consts
 class TodoViewModel(val repository: TodoRepository) : ViewModel() {
 
     val allTodos = MutableLiveData<List<TodoEntity>>()
-    val isCheckedState = MutableLiveData<Boolean>()
+    val entity = MutableLiveData<TodoEntity?>()
     val topVisibility = MutableLiveData<Boolean>()
 
     private fun insertTodo(entity: TodoEntity) {
@@ -28,13 +28,16 @@ class TodoViewModel(val repository: TodoRepository) : ViewModel() {
 
     fun checkTodo(entity: TodoEntity) {
         val nowChecked = !entity.isChecked
-        isCheckedState.postValue(nowChecked)
         updateTodo(TodoEntity(entity.id, entity.title, entity.description, nowChecked))
         loadAllTodos()
     }
 
     fun loadAllTodos() {
         allTodos.postValue(repository.getAllTodos())
+    }
+
+    fun setEntity(entity: TodoEntity) {
+        this.entity.postValue(entity)
     }
 
     fun switchVisibilityByTodos() {

--- a/app/src/test/java/com/example/todoappsandbox/ui/list/TodoViewModelTest.kt
+++ b/app/src/test/java/com/example/todoappsandbox/ui/list/TodoViewModelTest.kt
@@ -46,18 +46,6 @@ class TodoViewModelTest {
         verify(observer).onChanged(listOf(testEntity))
     }
 
-    @Test
-    fun verifyObserveTodoChecked() {
-        val checkedObserver = viewModel.isCheckedState.testObserver()
-
-        val testEntity = TodoEntity(1, "hoge", "piyo", isChecked = false)
-        `when`(repository.getAllTodos()).thenReturn(listOf(testEntity))
-
-        viewModel.loadAllTodos()
-        viewModel.checkTodo(testEntity)
-        verify(checkedObserver).onChanged(true)
-    }
-
     /**
      * make mock observer for liveData
      */


### PR DESCRIPTION
* entityをobserve対象とする
* 回転時に古いダイアログはdismissする
* 通常の回転時にはダイアログを生成したくないためロジックで制御